### PR TITLE
Fixed setuptools version to avoid error about pkg_resources not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ You should also add project tags for each release in Github, see [Managing relea
 - Separated Librispeech (English) data processing and model training from Common Voice (other languages)
 - Corpus-specific vocabulary files are loaded to compare expected vocabulary against actual vocabulary from training data
 - Added support for corpora with whitespace separated phonemes to determine vocabulary
+- Forced setuptools to use version <=80.10.2 in conda environments and pyproject.toml due to outdated use of `pkg_resources` in panphon, resulting in "ModuleNotFoundError: No module named 'pkg_resources'" error when calling panphon library functions
 
 ### Fixed
 - Drop rows with null values from Buckeye transcriptions

--- a/multipa.yml
+++ b/multipa.yml
@@ -9,3 +9,4 @@ dependencies:
   - torchvision=0.11.2
   - torchaudio=0.10.1
   - cudatoolkit=11.3
+  - setuptools<=80.10.2

--- a/multipa_cuda124.yml
+++ b/multipa_cuda124.yml
@@ -5,4 +5,4 @@ channels:
 dependencies:
   - python=3.11
   - pytorch-cuda=12.4
-  
+  - setuptools<=80.10.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 # A build system is required to convert your code into a distributable package.
 [build-system]
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools<=80.10.2"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
This fixes `env_cuda124/lib/python3.11/site-packages/panphon/featuretable.py:11: in <module>
    import pkg_resources
E   ModuleNotFoundError: No module named 'pkg_resources'`, which arose due to deprecation of pkg_resources in setuptools (removed officially in v82.0.0, see https://setuptools.pypa.io/en/latest/history.html#v82-0-0). The panphon library calls pkg_resources explicitly in its code, so we need to use an older version of setuptools until panphon is updated to remove calls to pkg_resources.

Specifically: 
- Set setuptools<=80.10.2 in Conda environment files
- Set setuptools<=80.10.2 in pyproject.toml