### PR TITLE
Dependency debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,9 @@ This started as a [Data Core Seed Funding](https://ds.cs.umass.edu/data-core-see
 The computational resources for this work are provided by the Unity Research Computing Platform, a multi-institutional cluster lead by University of Massachusetts Amherst, the University of Rhode Island, and University of Massachusetts Dartmouth.
 
 # Installation
-Use a virtual environment, such as conda.
-It's also a good idea to upgrade pip before you start: `pip install --upgrade pip`.
-Install pytorch dependencies first: `pip install pytorch==2.5.1 torchvision==0.20.0 torchaudio==2.5.1`. A conda environment for cuda 12.4 has been provided in `multipa.yml`. For other installation options and GPU settings, see [pytorch.org](https://pytorch.org).
-Then install remaining requirements: `pip install .`. You can run `pip install -e .[dev,test]` for the developer set up, after which the best way to check that the installation worked is to run unit tests with `pytest`. You will also need to download the unidic dictionary with `python -m unidic download` (in the same python environment as you installation).
+1. Create a conda environment using `conda env create --name <your_env_name> --file=<your_env_file>.yml`. A conda environment for cuda 12.4 has been provided in `multipa_cuda124.yml` for GPUs. A CPU compatible environment is in `multipa.yml`. For other installation options and GPU settings, see [pytorch.org](https://pytorch.org).
+
+2. Then install remaining requirements: `pip install .`. You can run `pip install -e .[dev,test]` for the developer set up, after which the best way to check that the installation worked is to run unit tests with `pytest`. You will also need to download the unidic dictionary with `python -m unidic download` (in the same python environment as you installation).
 
 For convenience, scripts for setup and installation are provided in `scripts/setup.sh` (local or personal computer) and `scripts/setup_slurm.sh` (Slurm compute cluster).
 

--- a/multipa.yml
+++ b/multipa.yml
@@ -6,3 +6,4 @@ dependencies:
   - numpy=1.21.5
   - pytorch=2.12.0
   - setuptools<=80.10.2
+  - ffmpeg

--- a/multipa.yml
+++ b/multipa.yml
@@ -1,12 +1,8 @@
 name: multipa
 channels:
   - pytorch
-  - nvidia
 dependencies:
-  - python=3.9
+  - python=3.11
   - numpy=1.21.5
-  - pytorch=1.10.1
-  - torchvision=0.11.2
-  - torchaudio=0.10.1
-  - cudatoolkit=11.3
+  - pytorch=2.12.0
   - setuptools<=80.10.2

--- a/multipa_cuda124.yml
+++ b/multipa_cuda124.yml
@@ -6,3 +6,4 @@ dependencies:
   - python=3.11
   - pytorch-cuda=12.4
   - setuptools<=80.10.2
+  - ffmpeg

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 # All the dependencies needed for running your module go here
 dependencies = [
-    "datasets==3.6.0",
+    "datasets[audio]==4.8.4",
     "epitran==1.24",
     "eng_to_ipa",
     "evaluate==0.4.3",
@@ -39,9 +39,7 @@ dependencies = [
     "pyarrow",
     "pydub==0.25.1",
     "romkan==0.2.1",
-    "torch==2.5.1",
-    "torchaudio==2.5.1",
-    "torchvision==0.20.1",
+    "torch",
     "transformers[torch]==4.43.4",
     "unidic==1.1.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "pyarrow",
     "pydub==0.25.1",
     "romkan==0.2.1",
-    "torch",
+    "torch==2.12.0",
     "transformers[torch]==4.43.4",
     "unidic==1.1.0",
 ]

--- a/src/multipa/main.py
+++ b/src/multipa/main.py
@@ -176,9 +176,15 @@ def check_gpus(expected_gpus: int = 0):
 
 def is_valid_sample(batch):
     audio = batch["audio"]
-    if len(audio["array"]) < 1600:  # 0.1 seconds at 16kHz
-        return False
-    if len(batch["ipa"]) == 0:
+    try:
+        if len(audio["array"]) < 1600:  # 0.1 seconds at 16kHz
+            return False
+        if len(batch["ipa"]) == 0:
+            return False
+    except RuntimeError:
+        # Sometimes torchcodec throws: RuntimeError: getFramesPlayedInRangeAudio,
+        # /Users/runner/work/torchcodec/torchcodec/meta-pytorch/torchcodec/src/torchcodec/_core/SingleStreamDecoder.cpp:1289,
+        # No audio frames were decoded. This is probably because start_seconds is too high(0),or because stop_seconds(nullopt) is too low.
         return False
     return True
 


### PR DESCRIPTION
A bug appeared in `datasets.load_dataset("audiofolder"...` suddenly, surfacing as "ValueError: `file_name` or `*_file_name` must be present as dictionary key (with type string) in metadata files", even though the data format hasn't changed. I suspect some change in dependency versions is at play from updates to setuptools and panphon recently. 

This brings datasets up to the latest version, which also required updating pytorch and adding torchcodec and ffmpeg to the environments as dependencies. The ValueError bug no longer appears. 